### PR TITLE
v0.9.2: cockpit light intensity multiplier + A340 detection fix

### DIFF
--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -61,6 +61,7 @@ set(PHOTON_CORE_SOURCES
     src/core/patch_acf.cpp
     src/core/patch_acf_screens.cpp
     src/core/patch_glow.cpp
+    src/core/patch_intensity.cpp
     src/core/patch_realwings.cpp
     src/core/config.cpp
     src/core/detect.cpp

--- a/src/native/src/core/actions.cpp
+++ b/src/native/src/core/actions.cpp
@@ -12,6 +12,7 @@
 #include "core/patch_acf.h"
 #include "core/patch_acf_screens.h"
 #include "core/patch_glow.h"
+#include "core/patch_intensity.h"
 #include "core/patch_realwings.h"
 #include "core/payload.h"
 #include "core/progress.h"
@@ -643,8 +644,25 @@ std::vector<std::string> InstallInterior(const Options& opts,
         steps.push_back(std::string("Backed up original ") + kInteriorObj + " → " +
                         BackupLabel(aircraftDir, backupDir));
     }
-    const std::string text =
+    std::string text =
         marker::Inject(payload::InteriorObjText(), kPhotonVersion, "interior");
+    // The cockpit-light intensity multiplier the user set on the plugin's
+    // Settings tab, read back out of the prefs file and re-applied to the
+    // fresh OBJ — without this every reinstall silently resets the cockpit to
+    // 1x, which reads as the install having broken the setting. Applied to the
+    // in-memory text so the aircraft still sees exactly one atomic write. A
+    // user who never touched the slider has no prefs entry, SavedFactor
+    // answers 1x, and the staged bytes are untouched.
+    const double intensityFactor = intensity::SavedFactor(opts.xplaneRoot);
+    if (!intensity::AtDefault(intensityFactor)) {
+        int scaledLines = 0;
+        text = intensity::PatchText(text, intensityFactor, scaledLines);
+        log.Write("cockpit light intensity " + intensity::Label(intensityFactor) +
+                  " from plugin settings applied to " +
+                  std::to_string(scaledLines) + " light line(s)");
+        steps.push_back("Applied your cockpit light intensity setting (" +
+                        intensity::Label(intensityFactor) + ")");
+    }
     log.Write("writing " + fsutil::PathToUtf8(target) + " (" +
               std::to_string(text.size()) + " bytes)");
     if (!dryRun) WriteOrThrow(target, text);

--- a/src/native/src/core/constants.cpp
+++ b/src/native/src/core/constants.cpp
@@ -29,7 +29,10 @@ const std::vector<Airframe>& Airframes() {
         {"a321", "ToLissA321*", "A321", "lights_out321_XP12.obj",
          "ToLiss A321", "/A321/", "A321"},
         {"a339", "ToLissA339*", "A339", "ExternalLights_XP12.obj",
-         "ToLiss A330-900", "/A330-900/", "A330-900"},
+         "ToLiss A330-900", "/A330-900/", "A330-900",
+         // ⚠ The one GENERIC objName above — an A340 carries the same file, so
+         // the fingerprint alone is not this airframe. See Airframe::acfIcao.
+         "A339"},
     };
     return kAirframes;
 }

--- a/src/native/src/core/constants.h
+++ b/src/native/src/core/constants.h
@@ -46,6 +46,17 @@ struct Airframe {
     // are mutually exclusive, so order between airframes is irrelevant.
     const char* cfgModule;   // "/A319/"
     const char* cfgName;     // "A319"
+    // ⚠ CORROBORATION FOR A GENERIC FINGERPRINT, empty for a model-specific
+    // one. `ExternalLights_XP12.obj` is ToLiss's own name for EVERY newer-
+    // generation airframe's exterior lights OBJ — the A340 ships it too, so
+    // presence alone misdetected an A340 as the A330-900 and let the installer
+    // modify it with a339 payloads (field report, 2026-08-16). When set, the
+    // objName fingerprint counts only if an `.acf` in the folder stamps this
+    // `acf/_ICAO` (the four ToLiss airframes here stamp A319/A20N/A321/A339 —
+    // read from the shipped files, like the FxFamilyForIcao list). The plugin
+    // corroborates through the sim's own ICAO dataref instead — same value,
+    // same equality.
+    const char* acfIcao = "";
 };
 
 const std::vector<Airframe>& Airframes();
@@ -188,6 +199,16 @@ bool PluginPathIsUserOwned(const std::string& relPosix);
 // itself and never after following it.
 constexpr char kPanelFxFile[] = "panelfx.txt";
 constexpr char kPluginDataDirName[] = "plugindata";
+
+// ─── the plugin's prefs file ─────────────────────────────────────────────────
+// `<X-Plane>/Output/preferences/ToLissPhoton_profiles.json` — WRITTEN by the
+// plugin only. The installer READS it for exactly one thing: the "$cockpit"
+// block's cockpit-light intensity multiplier, which it re-applies to a freshly
+// staged `lights_inn.obj` so a reinstall does not silently reset the user's
+// brightness (core/patch_intensity.h). The names live here because two halves
+// that each spelled them out is how a reader and a writer drift apart.
+constexpr char kProfilesJsonName[] = "ToLissPhoton_profiles.json";
+constexpr char kPrefsCockpitKey[] = "$cockpit";
 
 // ─── the OBJ version marker ──────────────────────────────────────────────────
 // `# ToLissPhoton version: X wing: Y`, injected after the OBJ's POINT_COUNTS line.

--- a/src/native/src/core/detect.cpp
+++ b/src/native/src/core/detect.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <fstream>
 #include <set>
 
 #include "core/constants.h"
@@ -54,6 +55,51 @@ std::string UpperCopy(const std::string& s) {
     std::transform(out.begin(), out.end(), out.begin(),
                    [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
     return out;
+}
+
+// Does any `.acf` in the aircraft folder stamp `P acf/_ICAO <want>`? The
+// corroboration behind `Airframe::acfIcao` — the file's own model identity,
+// the same content-over-naming rule as the format stamp `acf::FormatVersion`
+// reads. Any variant may answer: all four of a ToLiss folder's `.acf` files
+// carry the same ICAO, and this is identification, not patching, so the
+// XP11-pair rule does not apply.
+//
+// STREAMED, not ReadFileBytes: the property block is sorted, so `acf/_ICAO`
+// sits tens of thousands of lines into a 20-50 MB file, and whole-file reads
+// of all four variants would be most of a detection scan's I/O for one field.
+// Stops at the stamp or at PROPERTIES_END.
+//
+// ⚠ `.acf` EXACTLY — both wing mods leave `*.acf.bak` and
+// `*.acf.durantula.bak` copies behind forever, and a stale copy's ICAO is
+// exactly what this must not answer from. (`EndsWith(".acf")` excludes them.)
+bool FolderHasAcfIcao(const std::string& folderUtf8, const char* want) {
+    constexpr char kIcaoProp[] = "P acf/_ICAO ";
+    const std::string wantUpper = UpperCopy(want);
+    const fs::path folder = fsutil::PathFromUtf8(folderUtf8);
+    std::error_code ec;
+    for (fs::directory_iterator it(folder, ec), end; it != end;
+         it.increment(ec)) {
+        if (ec) break;
+        const fs::path& p = it->path();
+        const std::string name = fsutil::ToLower(fsutil::PathToUtf8(p.filename()));
+        if (!fsutil::EndsWith(name, ".acf")) continue;
+        std::error_code fec;
+        if (!fs::is_regular_file(p, fec) || fec) continue;
+        std::ifstream f(p, std::ios::binary);
+        if (!f) continue;
+        std::string line;
+        while (std::getline(f, line)) {
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            if (fsutil::StartsWith(line, kIcaoProp)) {
+                const std::string got =
+                    UpperCopy(fsutil::Trim(line.substr(sizeof(kIcaoProp) - 1)));
+                if (got == wantUpper) return true;
+                break;   // one stamp per file; try the next variant
+            }
+            if (line == "PROPERTIES_END") break;
+        }
+    }
+    return false;
 }
 
 }  // namespace
@@ -336,10 +382,21 @@ std::string IdentifyAirframe(const std::string& folderUtf8) {
         }
     }
     // 3. the airframe-specific OBJ filename — intrinsic to the aircraft's files.
+    //
+    // ⚠ A GENERIC fingerprint needs the `.acf`'s own word for it. The a339's
+    // `ExternalLights_XP12.obj` is ToLiss's name for every newer airframe's
+    // exterior lights OBJ — an A340 carries it too, and presence alone
+    // misdetected an A340 as an installable A330-900 (2026-08-16). A failed
+    // corroboration falls through rather than returning empty here: a real
+    // A339 whose `.acf` files are unreadable still identifies by step 4's
+    // folder glob, while an A340 matches nothing and stays off the list.
     const fs::path objects = fsutil::PathFromUtf8(folderUtf8) / "objects";
     for (const Airframe& af : Airframes()) {
         std::error_code ec;
-        if (fs::is_regular_file(objects / af.objName, ec) && !ec) return af.key;
+        if (!fs::is_regular_file(objects / af.objName, ec) || ec) continue;
+        if (af.acfIcao[0] != '\0' && !FolderHasAcfIcao(folderUtf8, af.acfIcao))
+            continue;
+        return af.key;
     }
     // 4. the legacy folder-name glob, last resort.
     const std::string folderName =

--- a/src/native/src/core/patch_intensity.cpp
+++ b/src/native/src/core/patch_intensity.cpp
@@ -1,0 +1,267 @@
+#include "core/patch_intensity.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "core/constants.h"
+#include "core/fsutil.h"
+#include "third_party/nlohmann/json.hpp"
+
+namespace photon {
+namespace intensity {
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Sized to the "%.2f" both the prefs file and the factor marker are written
+// with: two factors that render the same two-decimal string compare equal.
+constexpr double kEpsilon = 0.005;
+
+// One spelling for every number this patcher writes back into a light line.
+// %.6g keeps the generator's own look (whole numbers bare, no trailing zeros)
+// and cannot reach scientific notation in the sizes' range.
+std::string FormatNum(double v) {
+    char buf[40];
+    std::snprintf(buf, sizeof(buf), "%.6g", v);
+    return buf;
+}
+
+void SplitIndent(const std::string& line, std::string& indent,
+                 std::string& body) {
+    std::size_t i = 0;
+    while (i < line.size() && (line[i] == ' ' || line[i] == '\t')) ++i;
+    indent = line.substr(0, i);
+    body = line.substr(i);
+}
+
+struct Token {
+    std::size_t begin = 0;
+    std::size_t end = 0;   // one past
+    std::string text;
+};
+
+std::vector<Token> Tokens(const std::string& body) {
+    std::vector<Token> out;
+    std::size_t i = 0;
+    while (i < body.size()) {
+        while (i < body.size() && (body[i] == ' ' || body[i] == '\t')) ++i;
+        if (i >= body.size()) break;
+        Token t;
+        t.begin = i;
+        while (i < body.size() && body[i] != ' ' && body[i] != '\t') ++i;
+        t.end = i;
+        t.text = body.substr(t.begin, t.end - t.begin);
+        out.push_back(t);
+    }
+    return out;
+}
+
+// Which token is the brightness (`size`, the OBJ line's slot 8) for this light
+// line — or -1 for any line this patcher must leave alone. The two LIGHT_PARAM
+// classes are Gus's whole roster; an unknown class is somebody else's light.
+//
+//   LIGHT_PARAM <class> x y z  r g b  index SIZE  dx dy dz  cone     -> token 9
+//   LIGHT_SPILL_CUSTOM  x y z  r g b  alpha SIZE  dx dy dz  semi df  -> token 8
+int SizeTokenIndex(const std::vector<Token>& toks) {
+    if (toks.size() >= 14 && toks[0].text == "LIGHT_PARAM" &&
+        (toks[1].text == "airplane_panel_sp" ||
+         toks[1].text == "airplane_inst_sp")) {
+        return 9;
+    }
+    if (toks.size() >= 14 && toks[0].text == "LIGHT_SPILL_CUSTOM") return 8;
+    return -1;
+}
+
+// `body` with its size token scaled by `factor`; every other byte — spacing
+// included — is carried through untouched. Returns `body` unchanged when the
+// line does not parse (which the SizeTokenIndex gate makes unreachable, but a
+// patcher must not turn a surprise into a corrupt line).
+std::string ScaleSize(const std::string& body, double factor) {
+    const std::vector<Token> toks = Tokens(body);
+    const int idx = SizeTokenIndex(toks);
+    if (idx < 0) return body;
+    const Token& t = toks[static_cast<std::size_t>(idx)];
+    char* endp = nullptr;
+    const double v = std::strtod(t.text.c_str(), &endp);
+    if (endp == t.text.c_str()) return body;
+    return body.substr(0, t.begin) + FormatNum(v * factor) + body.substr(t.end);
+}
+
+}  // namespace
+
+double Clamp(double factor) {
+    // ⚠ The NaN-rejecting comparison: !(NaN >= kMin) is true, so garbage from a
+    // hand-edited prefs file lands on the harmless end of the range.
+    if (!(factor >= kMin)) return kMin;
+    if (factor > kMax) return kMax;
+    return factor;
+}
+
+bool AtDefault(double factor) { return SameFactor(factor, kDefault); }
+
+bool SameFactor(double a, double b) { return std::fabs(a - b) < kEpsilon; }
+
+std::string Label(double factor) {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.3gx", factor);
+    return buf;
+}
+
+double FactorIn(const std::string& text) {
+    for (const std::string& line : fsutil::SplitLines(text)) {
+        const std::string t = fsutil::Trim(line);
+        if (!fsutil::StartsWith(t, kFactorPrefix)) continue;
+        const std::string value = t.substr(sizeof(kFactorPrefix) - 1);
+        char* endp = nullptr;
+        const double f = std::strtod(value.c_str(), &endp);
+        if (endp == value.c_str()) return kDefault;
+        return f;
+    }
+    return kDefault;
+}
+
+bool CanPatch(const std::string& text) {
+    return text.find(kInteriorObjNeedle) != std::string::npos &&
+           text.find(kDebugNeedle) == std::string::npos;
+}
+
+std::string PatchText(const std::string& text, double factor, int& scaled) {
+    scaled = 0;
+    const double f = Clamp(factor);
+    const bool active = !AtDefault(f);
+    const std::string nl = fsutil::DetectNewline(text);
+    const std::vector<std::string> lines = fsutil::SplitLines(text);
+
+    std::vector<std::string> out;
+    out.reserve(lines.size() + 1);
+
+    // The original light line parsed out of a `# ToLissPhoton orig ` comment,
+    // waiting for the scaled line that follows it (which is discarded).
+    bool havePending = false;
+    std::string pendingOrig;
+    std::string pendingIndent;
+
+    for (const std::string& line : lines) {
+        std::string indent, body;
+        SplitIndent(line, indent, body);
+
+        // A previous patch's own lines are consumed, never copied: the factor
+        // marker is re-derived at the end, and an orig comment becomes the base
+        // for the light line that follows it.
+        if (fsutil::StartsWith(body, kFactorPrefix)) continue;
+        if (fsutil::StartsWith(body, kOrigPrefix)) {
+            pendingOrig = body.substr(sizeof(kOrigPrefix) - 1);
+            pendingIndent = indent;
+            havePending = true;
+            continue;
+        }
+
+        const bool isLight = SizeTokenIndex(Tokens(body)) >= 0;
+        if (!isLight) {
+            // ⚠ An orig comment not followed by a light line (a hand-edited
+            // file) is put back verbatim rather than silently swallowed.
+            if (havePending) {
+                out.push_back(pendingIndent + kOrigPrefix + pendingOrig);
+                havePending = false;
+            }
+            out.push_back(line);
+            continue;
+        }
+
+        // A light line. Its authored form is the preserved original when one
+        // is pending, else the line itself is still authored.
+        const std::string base = havePending ? pendingOrig : body;
+        const bool restored = havePending;
+        havePending = false;
+        if (active) {
+            out.push_back(indent + kOrigPrefix + base);
+            out.push_back(indent + ScaleSize(base, f));
+            ++scaled;
+        } else {
+            out.push_back(indent + base);
+            if (restored) ++scaled;
+        }
+    }
+    if (havePending) out.push_back(pendingIndent + kOrigPrefix + pendingOrig);
+
+    // The factor marker, after POINT_COUNTS like the installer's version
+    // marker — and only while a factor is applied, so a 1x file is exactly the
+    // authored one.
+    if (active) {
+        char buf[64];
+        std::snprintf(buf, sizeof(buf), "%s%.2f", kFactorPrefix, f);
+        bool inserted = false;
+        for (std::size_t i = 0; i < out.size(); ++i) {
+            if (fsutil::StartsWith(out[i], "POINT_COUNTS")) {
+                out.insert(out.begin() + static_cast<std::ptrdiff_t>(i) + 1,
+                           std::string(buf));
+                inserted = true;
+                break;
+            }
+        }
+        if (!inserted) out.insert(out.begin(), std::string(buf));
+    }
+    return fsutil::JoinLines(out, nl);
+}
+
+double SavedFactor(const std::string& xplaneRootUtf8) {
+    if (xplaneRootUtf8.empty()) return kDefault;
+    const fs::path p = fsutil::PathFromUtf8(xplaneRootUtf8) / "Output" /
+                       "preferences" / kProfilesJsonName;
+    std::string text;
+    if (!fsutil::ReadFileBytes(p, text)) return kDefault;
+    nlohmann::json root;
+    try {
+        root = nlohmann::json::parse(text);
+    } catch (const nlohmann::json::exception&) {
+        return kDefault;   // corrupt reads as "never set", never as an error
+    }
+    if (!root.is_object()) return kDefault;
+    const auto block = root.find(kPrefsCockpitKey);
+    if (block == root.end() || !block->is_object()) return kDefault;
+    const auto f = block->find(kIntensityJsonKey);
+    if (f == block->end() || !f->is_number()) return kDefault;
+    return Clamp(f->get<double>());
+}
+
+double FactorOfFile(const fs::path& obj) {
+    std::string text;
+    if (!fsutil::ReadFileBytes(obj, text)) return kDefault;
+    return FactorIn(text);
+}
+
+Applied ApplyToFile(const fs::path& obj, double factor, std::string& detail) {
+    const double f = Clamp(factor);
+    std::string text;
+    if (!fsutil::ReadFileBytes(obj, text)) {
+        detail = "could not read " + fsutil::PathToUtf8(obj);
+        return Applied::kFailed;
+    }
+    if (!CanPatch(text)) {
+        detail = fsutil::PathToUtf8(obj.filename()) +
+                 " is not a patchable Photon interior OBJ (stock, or a --debug "
+                 "build) - left alone";
+        return Applied::kSkipped;
+    }
+    if (SameFactor(FactorIn(text), f)) {
+        detail = "already at " + Label(f);
+        return Applied::kAlready;
+    }
+    int scaled = 0;
+    const std::string patched = PatchText(text, f, scaled);
+    std::error_code ec;
+    if (!fsutil::AtomicWriteBytes(obj, patched, ec)) {
+        detail = "could not write " + fsutil::PathToUtf8(obj) + " (" +
+                 ec.message() + ")";
+        return Applied::kFailed;
+    }
+    detail = Label(f) + " applied to " + std::to_string(scaled) +
+             " light line(s) - takes effect on the next aircraft load";
+    return Applied::kPatched;
+}
+
+}  // namespace intensity
+}  // namespace photon

--- a/src/native/src/core/patch_intensity.h
+++ b/src/native/src/core/patch_intensity.h
@@ -1,0 +1,111 @@
+// The cockpit-light intensity multiplier — scales the brightness of every
+// interior ("Gus Mod") light by rewriting `lights_inn.obj` IN PLACE.
+//
+// Why a file rewrite and not a dataref: the interior's 87 LIGHT_PARAM lamps
+// (`airplane_panel_sp` / `airplane_inst_sp`) have no per-light dataref hook, and
+// converting them to LIGHT_SPILL_CUSTOM so one could be added was tried and
+// rejected — it changes the rendered look, and it buys a per-frame callback per
+// light for a value that changes once a month. So the light TYPES stay exactly
+// as Gus authored them and the multiplier is baked into the one slot every line
+// already has: slot 8, the `size` — the same slot `optimize: boost` scales in
+// the DSL and the screen glow drives at runtime, i.e. the codebase's one
+// established brightness lever. A change therefore lands on the next aircraft
+// load, and both writers say so.
+//
+// ⚠ TWO WRITERS, ONE PATCH. The plugin applies the factor when the user moves
+// the Settings-tab slider and again on aircraft load when the file disagrees
+// with the saved setting; the installer applies it right after staging a fresh
+// `lights_inn.obj`, reading the saved factor out of the plugin's prefs file —
+// without that, every reinstall would silently reset the cockpit to 1x. Both
+// go through PatchText, so the file cannot come to carry two dialects.
+//
+// ⚠ THE PATCH IS RECOMPUTED FROM PRESERVED ORIGINALS, NEVER COMPOUNDED. Every
+// scaled light line is preceded by a `# ToLissPhoton orig <line>` comment
+// holding the authored line verbatim (OBJ8 treats `#` lines as comments — the
+// generated file is already full of them). Re-patching parses the original out
+// of the comment and scales THAT, so 2x then 3x equals 3x exactly, float
+// round-trips never accumulate, and 1x restores the file byte-for-byte —
+// which also means a 1x file carries no trace of this mechanism at all.
+//
+// ⚠ `kInteriorObjNeedle` must survive the patch untouched: it is the cockpit
+// submenu sentinel, and the category `ANIM_hide` gates that carry it are not
+// light lines. Same for the installer's `# ToLissPhoton version:` marker.
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace photon {
+namespace intensity {
+
+// The user-facing range. 1.0 is Gus's authored brightness; the ceiling is high
+// enough to out-shine a dimming environment mod and low enough that a spill
+// light's pool cannot swallow the whole flight deck.
+constexpr double kMin = 1.0;
+constexpr double kMax = 4.0;
+constexpr double kDefault = 1.0;
+
+// The two comment prefixes this patcher owns. Distinct from the installer's
+// version marker (`# ToLissPhoton version: `) by their next word, so
+// marker::Parse and FactorIn can never read each other's lines.
+constexpr char kFactorPrefix[] = "# ToLissPhoton intensity: ";
+constexpr char kOrigPrefix[] = "# ToLissPhoton orig ";
+
+// ⚠ A `--debug` interior OBJ reads every light's parameters from the dev
+// tuning datarefs, so patching its baked numbers would change nothing and
+// confuse the tuning session's save/restore. Its presence needle.
+constexpr char kDebugNeedle[] = "ToLissPhoton/debug/";
+
+// The prefs-file key the factor is saved under, inside the "$cockpit" global
+// block (constants.h has the block key and the filename). The plugin WRITES
+// the JSON through these constants and SavedFactor READS through them, which
+// is what keeps the two halves agreeing by construction.
+constexpr char kIntensityJsonKey[] = "intensity";
+
+double Clamp(double factor);
+bool AtDefault(double factor);
+// Factors compare through one epsilon everywhere, sized to the "%.2f" both
+// writers use, so "already applied" can never disagree between the two halves.
+bool SameFactor(double a, double b);
+
+// "2x" / "2.5x" — the one spelling for logs and install-step messages.
+std::string Label(double factor);
+
+// The factor recorded in `text` by a previous PatchText; kDefault when none.
+// ⚠ Deliberately NOT clamped: a hand-edited out-of-range marker must compare
+// unequal to every legal setting so the next apply repairs the file.
+double FactorIn(const std::string& text);
+
+// Is this a Photon interior OBJ this patcher may touch? True only for text
+// binding our interior datarefs and NOT a --debug build. Callers skip, never
+// error, on false — the stock ToLiss lights_inn.obj must never be rewritten.
+bool CanPatch(const std::string& text);
+
+// Rewrite every interior light line (LIGHT_PARAM airplane_panel_sp /
+// airplane_inst_sp, LIGHT_SPILL_CUSTOM) to `factor`, working from the
+// preserved originals. `scaled` = lines whose emitted form was scaled (or, at
+// 1x, restored). Newline flavor and every non-light byte are preserved.
+std::string PatchText(const std::string& text, double factor, int& scaled);
+
+// The saved multiplier from `<xplaneRoot>/Output/preferences/` +
+// kProfilesJsonName, "$cockpit"."intensity". kDefault when the file, the block
+// or the key is absent or unreadable — a user who never touched the slider has
+// no entry, and that must read as 1x, never as an error.
+double SavedFactor(const std::string& xplaneRootUtf8);
+
+// FactorIn of a file on disk; kDefault when unreadable.
+double FactorOfFile(const std::filesystem::path& obj);
+
+enum class Applied {
+    kPatched,   // the file was rewritten and now carries `factor`
+    kAlready,   // it already did — nothing written
+    kSkipped,   // not a patchable Photon interior OBJ (stock, debug, missing)
+    kFailed,    // read or write error; `detail` says which
+};
+
+// Read-check-patch-write one file. `detail` always carries a loggable line.
+Applied ApplyToFile(const std::filesystem::path& obj, double factor,
+                    std::string& detail);
+
+}  // namespace intensity
+}  // namespace photon

--- a/src/native/src/core/version.h
+++ b/src/native/src/core/version.h
@@ -26,6 +26,6 @@
 
 namespace photon {
 
-constexpr char kPhotonVersion[] = "0.9.1";
+constexpr char kPhotonVersion[] = "0.9.2";
 
 }  // namespace photon

--- a/src/native/src/plugin.cpp
+++ b/src/native/src/plugin.cpp
@@ -58,6 +58,16 @@
 #include "core/constants.h"
 #include "core/version.h"
 
+// The cockpit-light intensity multiplier's patcher. Shared with the installer,
+// which re-applies the saved factor to a freshly staged lights_inn.obj; the
+// plugin applies it from the Settings tab and on aircraft load. The one place
+// the shipping .xpl writes into an aircraft folder — a baked-value rewrite of
+// OUR OWN interior OBJ only (ApplyToFile refuses anything else), because the
+// 87 LIGHT_PARAM lamps have no dataref hook and changing their light type to
+// get one was tried and rejected (it changes the look, and it buys a per-frame
+// callback per light for a value that changes once a month).
+#include "core/patch_intensity.h"
+
 // Every window in this plugin is Dear ImGui, shipping ones included, so the
 // backend comes in unconditionally.
 #include "imgui_xplm.h"
@@ -203,8 +213,27 @@ static const char* kIntOptimizedRef = "ToLissPhoton/interior/optimized";
 
 struct CockpitSettings {
     bool optimized = false;      // false = Gus's full stack
+    // The intensity multiplier baked into lights_inn.obj (1.0 = Gus's authored
+    // brightness). ⚠ NOT a dataref and not read per frame: the value lives in
+    // the OBJ's own light lines (core/patch_intensity.h), so changing it means
+    // rewriting the file and reloading the aircraft. Global for the same reason
+    // `optimized` is — the interior OBJ is byte-identical across A319/A320/A321
+    // and "my cockpit is too dim" is a statement about this machine's setup
+    // (environment mods, monitor), not about one paint scheme.
+    float intensity = 1.0f;
 };
 static CockpitSettings gCockpit;
+
+// What the OBJ the sim ACTUALLY LOADED carries, captured by DetectInstall
+// before the on-load re-apply brings the file up to date. The Settings tab
+// compares it against gCockpit.intensity to say "takes effect after reload"
+// exactly when that is true — the file on disk is no guide, because the sim
+// renders what it read at load time, not what is there now.
+static float gIntensityLoadedFactor = 1.0f;
+
+static float ClampIntensity(float v) {
+    return (float)photon::intensity::Clamp((double)v);
+}
 
 // Needed only by the prefs migration below. Kept next to the table so a reorder
 // is caught by eye rather than by a wrong-looking cockpit.
@@ -1992,12 +2021,21 @@ static void DisplaysFromJson(const json::Value& v) {
 // Its own key rather than a member of "$displays" because that block is about
 // the SCREENS and this is about the cockpit lamps; a reader should not have to
 // know that "displays" grew a cockpit setting.
-static const char* kCockpitKey = "$cockpit";
+// ⚠ THE INSTALLER READS THIS BLOCK (core/patch_intensity.cpp SavedFactor), so
+// its key and the intensity key come from constants.h rather than being spelled
+// here — a reader and a writer that each owned their literal is how the two
+// halves would drift.
+static const char* kCockpitKey = photon::kPrefsCockpitKey;
 
 static void CockpitFromJson(const json::Value& v) {
     if (v.type != json::Value::Obj) return;
     const json::Value* p = v.find("optimized");
     if (p && p->type == json::Value::Int) gCockpit.optimized = p->i != 0;
+    const json::Value* f = v.find(photon::intensity::kIntensityJsonKey);
+    // ⚠ `d`, never `i` — the parser types every number Int and fills both, and
+    // `i` would truncate 2.5x to 2x (see the gain note in DisplaysFromJson).
+    if (f && f->type == json::Value::Int)
+        gCockpit.intensity = ClampIntensity((float)f->d);
 }
 
 // The third global block: the waveform override (see ExteriorSettings). Its own
@@ -2061,9 +2099,12 @@ static void SaveProfilesFile() {
         // means default" is only safe for a setting whose default is a state the
         // user can also choose on purpose, and a switch has no such reading.
         {
-            char buf[96];
-            std::snprintf(buf, sizeof(buf), ",\n  \"%s\": {\"optimized\": %d}",
-                          kCockpitKey, gCockpit.optimized ? 1 : 0);
+            char buf[128];
+            std::snprintf(buf, sizeof(buf),
+                          ",\n  \"%s\": {\"optimized\": %d, \"%s\": %.2f}",
+                          kCockpitKey, gCockpit.optimized ? 1 : 0,
+                          photon::intensity::kIntensityJsonKey,
+                          gCockpit.intensity);
             f << buf;
         }
         // And the third. Always written, same argument again: "absent means
@@ -2225,6 +2266,45 @@ static void SetCockpitOptimized(bool on) {
     UpdateChecks();
     Log(std::string("cockpit lights: ")
         + (on ? "optimized (one light per position)" : "full stack"));
+}
+
+// The loaded aircraft's interior OBJ, or empty when there is no aircraft path.
+static fs::path LoadedInteriorObjPath() {
+    char fileName[512] = {0}, path[512] = {0};
+    XPLMGetNthAircraftModel(0, fileName, path);
+    if (!path[0]) return fs::path();
+    return fs::path(path).parent_path() / "objects" / kInteriorObjName;
+}
+
+// Bake gCockpit.intensity into the loaded aircraft's lights_inn.obj. Called
+// from the Settings-tab slider's commit and from the aircraft-load path — the
+// second is what carries one saved setting to all three A3xx airframes: each
+// converges the next time it is loaded, with no walk of the Aircraft folder.
+//
+// ⚠ Both gates, deliberately: `gInteriorInstalled` because there is nothing of
+// ours to rewrite otherwise (ApplyToFile would refuse the stock file anyway —
+// this is the cheap first layer), and `!gInstallStale` because the contract for
+// a reverted install is to do NOTHING, file writes included. The quiet case
+// (already at the saved factor — every load after the first) logs nothing.
+static void ApplyInteriorIntensity(const char* why) {
+    if (!gInteriorInstalled || gInstallStale) return;
+    const fs::path obj = LoadedInteriorObjPath();
+    if (obj.empty()) return;
+    std::string detail;
+    const photon::intensity::Applied r = photon::intensity::ApplyToFile(
+        obj, (double)gCockpit.intensity, detail);
+    if (r == photon::intensity::Applied::kAlready) return;
+    Log(std::string("cockpit light intensity (") + why + "): " + detail);
+}
+
+// The intensity slider's commit — on RELEASE, never per drag tick: this one
+// rewrites a file where its neighbors flip a flag. The field itself is updated
+// live by the slider so the label tracks the drag; committing an unchanged
+// value costs one small read (ApplyToFile answers "already").
+static void CommitCockpitIntensity() {
+    gCockpit.intensity = ClampIntensity(gCockpit.intensity);
+    SaveProfilesFile();
+    ApplyInteriorIntensity("setting changed");
 }
 
 // The waveform override, same shape as the two above: one flag, no per-livery
@@ -2943,6 +3023,37 @@ static void BuildSettingsTab() {
                   "effects switched off one at a time, so you can see what each "
                   "of them costs on this machine.");
 
+    // The cockpit-light intensity multiplier — its own section, because unlike
+    // everything under Performance it is a LOOK, not a cost. It still belongs
+    // on THIS tab: like `optimized` it is one global statement about the
+    // machine (the interior OBJ is byte-identical across the three A3xx), not
+    // a per-livery era choice, and the Cockpit tab is the era grid. HIDDEN,
+    // not grayed, where the mod is not installed — same rule and same reason
+    // as the simplified-floods row above.
+    if (gInteriorInstalled) {
+        ImGui::Spacing();
+        ImGui::SeparatorText("Cockpit lighting");
+        ImGui::Spacing();
+        float v = gCockpit.intensity;
+        ImGui::SetNextItemWidth(220.0f);
+        // The field updates live so the readout tracks the drag; the file
+        // write and the prefs save wait for the RELEASE (the commit below).
+        if (ImGui::SliderFloat("Brightness", &v,
+                               (float)photon::intensity::kMin,
+                               (float)photon::intensity::kMax, "%.1fx"))
+            gCockpit.intensity = ClampIntensity(v);
+        if (ImGui::IsItemDeactivatedAfterEdit()) CommitCockpitIntensity();
+        UiHelpMarker("You can increase the brightness of the cockpit lighting "
+                     "if you find it is too dark. You must restart the "
+                     "simulator to see the changes.");
+        // Shown exactly while what the sim RENDERS (captured at load) differs
+        // from the setting — not while the file differs, which it stops doing
+        // the moment the commit rewrites it.
+        if (!photon::intensity::SameFactor((double)gIntensityLoadedFactor,
+                                           (double)gCockpit.intensity))
+            UiHint("Must restart X-Plane to see changes.");
+    }
+
     // COLLAPSED by default and under its own header. Everything above answers
     // "what may this cost?", which is a question with an obvious right answer for
     // most people; this one answers "how much may the plugin change?", which is
@@ -3528,6 +3639,7 @@ static void DetectInstall() {
     const fs::path objects = fs::path(path).parent_path() / "objects";
 
     ObjScan ext = kObjUnreadable;
+    const std::string icao = AircraftIcao();
     for (const photon::Airframe& af : photon::Airframes()) {
         const fs::path obj = objects / af.objName;
         std::error_code ec;
@@ -3536,6 +3648,22 @@ static void DetectInstall() {
         // would make "present but unreadable" indistinguishable from "a different
         // airframe" and walk on to try the other three.
         if (!fs::is_regular_file(obj, ec)) continue;
+        // ⚠ A GENERIC fingerprint needs the aircraft's own word for it — the
+        // installer's IdentifyAirframe corroborates against the `.acf`'s
+        // acf/_ICAO stamp, and this is the same test read the cheap way, off
+        // the sim's own dataref for the loaded aircraft. Without it an A340
+        // (which carries the a339's ExternalLights_XP12.obj too) resolved as
+        // an a339 whose OBJ is stock, i.e. gInstallStale — a Reinstall-
+        // required menu pointing at an installer that (rightly) refuses the
+        // aircraft. An A340 is UNRECOGNIZED, never stale.
+        //
+        // ⚠ Only a POSITIVE mismatch rejects. An empty read is "could not
+        // tell", and the rule is ScanObj's: evidence may disable, its absence
+        // may not — DetectInstall runs once per load with no 1 Hz retry, so a
+        // transiently empty dataref would otherwise keep a genuine A339 dark
+        // for the whole session.
+        if (af.acfIcao[0] != '\0' && !icao.empty() && icao != af.acfIcao)
+            continue;
         gAirframeKey = af.key;
         ext = ScanObj(obj, kExteriorObjNeedle);
         break;
@@ -3560,6 +3688,15 @@ static void DetectInstall() {
     // wrong way.
     gInteriorInstalled = ScanObj(objects / kInteriorObjName, kInteriorObjNeedle)
                        == kObjModded;
+    // What the sim just LOADED is what it renders until the next reload —
+    // captured here, before the on-load re-apply in UpdateMenuVisibility
+    // brings the file itself up to date. The Settings tab's "takes effect
+    // after the aircraft is reloaded" hint compares against exactly this;
+    // the file on disk is no guide once it has been re-patched.
+    gIntensityLoadedFactor =
+        gInteriorInstalled
+            ? (float)photon::intensity::FactorOfFile(objects / kInteriorObjName)
+            : 1.0f;
 
     if (gInstallStale) {
         Log("INSTALL REVERTED: " + gAirframeKey + "/objects/"
@@ -3666,6 +3803,12 @@ static void UpdateMenuVisibility() {
             PerfShutdown();
             return;
         }
+        // Bring this aircraft's lights_inn.obj up to the saved intensity —
+        // the aircraft that just loaded may not be the one the slider was
+        // moved on, and a reinstall may have reset the file. The common case
+        // (already right) is one small read; the change lands next reload,
+        // which the Settings tab says whenever it is true.
+        ApplyInteriorIntensity("aircraft load");
         ResolveGlowMap();      // pick the skin-glow index map for this airframe
         // ToLiss's own glow array, the pass-through source for the redirected
         // regions while the waveform override is off. Bound here and retried at

--- a/src/native/tests/core_tests.cpp
+++ b/src/native/tests/core_tests.cpp
@@ -24,6 +24,7 @@
 #include "core/patch_acf.h"
 #include "core/patch_acf_screens.h"
 #include "core/patch_glow.h"
+#include "core/patch_intensity.h"
 #include "core/patch_realwings.h"
 #include "core/version.h"
 #include "installer/tui.h"
@@ -1457,6 +1458,139 @@ TEST("tui: a body that fits shows no scroll markers at all") {
     const std::string frame = tui::ComposeFrame(1, {"just", "a", "few", "rows"});
     CHECK(frame.find("more above") == std::string::npos);
     CHECK(frame.find("more below") == std::string::npos);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// intensity — the cockpit-light multiplier baked into lights_inn.obj
+// ─────────────────────────────────────────────────────────────────────────────
+namespace {
+
+// A miniature of the real generated file: CRLF, tab-indented light lines of all
+// three kinds inside an ANIM gate, the interior needle carried by the gate's
+// dataref, and a POINT_COUNTS line for the factor marker to anchor on. The
+// numbers are real ones from dist/A320/objects/lights_inn.obj.
+std::string InnObjFixture() {
+    return
+        "I\r\n800\r\nOBJ\r\n\r\nTEXTURE\t\r\nPOINT_COUNTS\t0 0 1 0\r\n"
+        "# ToLiss Photon Lighting - interior (cockpit) lights\r\n"
+        "ANIM_begin\r\n"
+        "\tANIM_hide 0.5 2.5 ToLissPhoton/interior/dome\r\n"
+        "\t# Dome Lights -> Old Halogen\r\n"
+        "\tLIGHT_PARAM\tairplane_panel_sp -0.472 1.09 -3.35 1 0.37 0.16 0 "
+        "1.414 0 0 0 1\r\n"
+        "\tLIGHT_PARAM\tairplane_inst_sp -1.147 0.033 -4.2 1 0.37 0.16 22 "
+        "0.4 0 -1 0 0.4\r\n"
+        "\tLIGHT_SPILL_CUSTOM\t0.244 1.097 -3.463 1 0.37 0.16 0.25 1 "
+        "0.146 -0.799 -0.584 0.97 ToLissPhoton/interior/spill/map\r\n"
+        "ANIM_end\r\n";
+}
+
+bool HasLine(const std::string& text, const std::string& needle) {
+    return text.find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+TEST("intensity: PatchText scales slot 8 of every light kind and nothing else") {
+    int scaled = 0;
+    const std::string out = intensity::PatchText(InnObjFixture(), 2.0, scaled);
+    CHECK_EQ(scaled, 3);
+    // slot 8 doubled; position, color, rheostat index, aim and cone untouched
+    CHECK(HasLine(out, "airplane_panel_sp -0.472 1.09 -3.35 1 0.37 0.16 0 "
+                       "2.828 0 0 0 1"));
+    CHECK(HasLine(out, "airplane_inst_sp -1.147 0.033 -4.2 1 0.37 0.16 22 "
+                       "0.8 0 -1 0 0.4"));
+    CHECK(HasLine(out, "LIGHT_SPILL_CUSTOM\t0.244 1.097 -3.463 1 0.37 0.16 "
+                       "0.25 2 0.146 -0.799 -0.584 0.97 "
+                       "ToLissPhoton/interior/spill/map"));
+    // each scaled line rides with its authored original...
+    CHECK(HasLine(out, std::string(intensity::kOrigPrefix) +
+                           "LIGHT_PARAM\tairplane_panel_sp -0.472"));
+    // ...the gate (the cockpit-submenu sentinel) is untouched...
+    CHECK(HasLine(out, "ANIM_hide 0.5 2.5 ToLissPhoton/interior/dome"));
+    CHECK(intensity::CanPatch(out));
+    // ...and the applied factor reads back.
+    CHECK(intensity::SameFactor(intensity::FactorIn(out), 2.0));
+    CHECK(intensity::SameFactor(intensity::FactorIn(InnObjFixture()), 1.0));
+}
+
+TEST("intensity: repatching recomputes from the originals, never compounds") {
+    // 2x then 3x must equal 3x applied once — byte for byte, not merely
+    // numerically — or every adjustment would drift the file a little further
+    // from Gus's authored values.
+    int n = 0;
+    const std::string direct = intensity::PatchText(InnObjFixture(), 3.0, n);
+    const std::string stepped = intensity::PatchText(
+        intensity::PatchText(InnObjFixture(), 2.0, n), 3.0, n);
+    CHECK_EQ(stepped, direct);
+}
+
+TEST("intensity: 1x restores the authored bytes exactly") {
+    // The mechanism must leave NO trace at 1x — no marker, no orig comments —
+    // so a user who tried the slider and put it back has the file the
+    // installer staged, and a byte-diff against the payload stays clean.
+    int n = 0;
+    const std::string patched = intensity::PatchText(InnObjFixture(), 2.0, n);
+    const std::string restored = intensity::PatchText(patched, 1.0, n);
+    CHECK_EQ(restored, InnObjFixture());
+    CHECK_EQ(n, 3);   // three lines restored
+}
+
+TEST("intensity: newline flavor is preserved both ways") {
+    // The shipped file is CRLF; a `--target interior --write` dev build may be
+    // LF. Either way the patch must not be a whole-file line-ending diff.
+    int n = 0;
+    CHECK(intensity::PatchText(InnObjFixture(), 2.0, n).find("\r\n") !=
+          std::string::npos);
+    std::string lf = InnObjFixture();
+    std::string noCr;
+    for (char c : lf) {
+        if (c != '\r') noCr.push_back(c);
+    }
+    CHECK(intensity::PatchText(noCr, 2.0, n).find('\r') == std::string::npos);
+}
+
+TEST("intensity: CanPatch refuses a stock OBJ and a --debug build") {
+    // The stock ToLiss lights_inn.obj binds none of our datarefs; a --debug
+    // build reads its lights from the dev tuning datarefs, so baked numbers do
+    // nothing there and the tuning session must not meet a rewritten file.
+    CHECK(intensity::CanPatch(InnObjFixture()));
+    CHECK(!intensity::CanPatch(
+        "I\r\n800\r\nOBJ\r\nLIGHT_PARAM\tairplane_panel_sp 0 0 0 1 1 1 0 1 "
+        "0 0 0 1\r\n"));
+    CHECK(!intensity::CanPatch(InnObjFixture() +
+                               "# ToLissPhoton/debug/light/0\r\n"));
+}
+
+TEST("intensity: out-of-range and garbage factors clamp to the harmless end") {
+    CHECK(intensity::SameFactor(intensity::Clamp(0.0), 1.0));
+    CHECK(intensity::SameFactor(intensity::Clamp(-3.0), 1.0));
+    CHECK(intensity::SameFactor(intensity::Clamp(99.0), 4.0));
+    int n = 0;
+    // A clamped-to-1x patch is a no-op that leaves no marker behind.
+    CHECK_EQ(intensity::PatchText(InnObjFixture(), 0.5, n), InnObjFixture());
+}
+
+TEST("intensity: SavedFactor reads the plugin's prefs, absent means 1x") {
+    TempDir tmp;
+    const std::string root = fsutil::PathToUtf8(tmp.path());
+    // no prefs file at all — a user who never touched the slider
+    CHECK(intensity::SameFactor(intensity::SavedFactor(root), 1.0));
+    const fs::path prefs =
+        tmp / "Output" / "preferences" / kProfilesJsonName;
+    // the shape the plugin writes, livery entries and all
+    Write(prefs,
+          "{\n  \"$displays\": {\"enabled\": 1},\n"
+          "  \"$cockpit\": {\"optimized\": 0, \"intensity\": 2.50},\n"
+          "  \"C:/Aircraft/a320.acf#0\": {\"profile\": 3}\n}\n");
+    CHECK(intensity::SameFactor(intensity::SavedFactor(root), 2.5));
+    // a factor outside the range clamps rather than propagating
+    Write(prefs, "{\"$cockpit\": {\"intensity\": 99}}");
+    CHECK(intensity::SameFactor(intensity::SavedFactor(root), 4.0));
+    // ⚠ corrupt reads as "never set", never as an error — same rule as the
+    // manifest's parser.
+    Write(prefs, "{not json");
+    CHECK(intensity::SameFactor(intensity::SavedFactor(root), 1.0));
 }
 
 int main(int argc, char** argv) { return photontest::RunAll(argc, argv); }

--- a/src/native/tests/install_tests.cpp
+++ b/src/native/tests/install_tests.cpp
@@ -30,8 +30,10 @@
 #include "core/detect.h"
 #include "core/fsutil.h"
 #include "core/manifest.h"
+#include "core/marker.h"
 #include "core/patch_acf.h"
 #include "core/patch_acf_screens.h"
+#include "core/patch_intensity.h"
 #include "core/patch_realwings.h"
 #include "core/payload.h"
 #include "core/progress.h"
@@ -205,9 +207,14 @@ public:
                                   "# payload obj ") + af.key + " " + wing + "\n");
             }
         }
+        // One real light line rides in the stub so the intensity re-apply has
+        // a slot 8 to scale — the numbers are the dome lamp's from the real
+        // generated file.
         Write(root_ / "objs" / "interior" / kInteriorObj,
               "I\n800\nOBJ\n\nPOINT_COUNTS\t0\t0\t0\t0\n"
-              "# ToLissPhoton/interior/dome\n");
+              "# ToLissPhoton/interior/dome\n"
+              "\tLIGHT_PARAM\tairplane_panel_sp -0.472 1.09 -3.35 1 0.37 0.16 "
+              "0 1.414 0 0 0 1\n");
         // ⚠ PER AIRFRAME, and the stub says WHICH — the whole hazard this layout
         // exists to remove is installing one airframe's six positions into
         // another, where every light draws and every light is in the wrong place.
@@ -421,6 +428,68 @@ TEST("detect: a folder that is none of ours identifies as nothing") {
     const fs::path dir = tmp / "Cessna 172";
     Write(dir / "objects" / "wing.obj", "I\n800\nOBJ\n");
     CHECK(detect::IdentifyAirframe(U8(dir)).empty());
+}
+
+TEST("detect: the a339 fingerprint needs the .acf's ICAO — an A340 is nobody") {
+    // ⚠ ExternalLights_XP12.obj is ToLiss's name for EVERY newer airframe's
+    // exterior lights OBJ — the A340 carries it too, and presence alone put an
+    // A340 on the installer's aircraft list as an installable A330-900 (field
+    // report, 2026-08-16). Its cfg does not save it: the module URL and the
+    // display name match no row, so the walk falls through to the fingerprint.
+    TempDir tmp;
+    const fs::path dir = tmp / "ToLissA340_V1p0p0";
+    Write(dir / "skunkcrafts_updater.cfg",
+          SkunkCfg("https://x/aircraft-repositories/A340-600/",
+                   "ToLiss A340-600", "1.0.0"));
+    Write(dir / "objects" / "ExternalLights_XP12.obj", "I\n800\nOBJ\n");
+    Write(dir / "A340-600.acf",
+          "I\r\n1200 Version\r\nACF\r\nPROPERTIES_BEGIN\r\n"
+          "P acf/_ICAO A346\r\nPROPERTIES_END\r\n");
+    CHECK(detect::IdentifyAirframe(U8(dir)).empty());
+}
+
+TEST("detect: the same fingerprint WITH the A330-900's stamp is the a339") {
+    // The corroborating half of the test above: a renamed A339 folder with no
+    // usable cfg still identifies, because its own .acf says who it is.
+    TempDir tmp;
+    const fs::path dir = tmp / "My Widebody";
+    Write(dir / "objects" / "ExternalLights_XP12.obj", "I\n800\nOBJ\n");
+    Write(dir / "A330-900.acf",
+          "I\r\n1200 Version\r\nACF\r\nPROPERTIES_BEGIN\r\n"
+          "P acf/_ICAO A339\r\nPROPERTIES_END\r\n");
+    CHECK_EQ(detect::IdentifyAirframe(U8(dir)), std::string("a339"));
+    // ⚠ and a leftover `.acf.bak` with the WRONG stamp must not poison it —
+    // both wing mods leave such copies behind forever.
+    Write(dir / "A330-900.acf.bak",
+          "I\r\n1200 Version\r\nACF\r\nPROPERTIES_BEGIN\r\n"
+          "P acf/_ICAO A346\r\nPROPERTIES_END\r\n");
+    CHECK_EQ(detect::IdentifyAirframe(U8(dir)), std::string("a339"));
+}
+
+TEST("detect: an a339 whose .acf cannot corroborate falls to the folder glob") {
+    // ⚠ The corroboration must fail OPEN for the real aircraft: a damaged A339
+    // install with no readable .acf still identifies by step 4's folder-name
+    // glob rather than vanishing from the list.
+    TempDir tmp;
+    const fs::path dir = tmp / "ToLissA339_V1p0p4";
+    Write(dir / "objects" / "ExternalLights_XP12.obj", "I\n800\nOBJ\n");
+    CHECK_EQ(detect::IdentifyAirframe(U8(dir)), std::string("a339"));
+}
+
+TEST("detect: an A340 does not appear in the aircraft list at all") {
+    // The user-visible half: DetectAircraft drops what IdentifyAirframe cannot
+    // name, and all three front-ends render that list verbatim — so this IS
+    // the "not shown as supported" contract.
+    TempDir tmp;
+    const fs::path root = tmp / "X-Plane 12";
+    std::error_code ec;
+    fs::create_directories(root / "Resources" / "plugins", ec);
+    const fs::path dir = root / "Aircraft" / "ToLissA340_V1p0p0";
+    Write(dir / "objects" / "ExternalLights_XP12.obj", "I\n800\nOBJ\n");
+    Write(dir / "A340-600.acf",
+          "I\r\n1200 Version\r\nACF\r\nPROPERTIES_BEGIN\r\n"
+          "P acf/_ICAO A346\r\nPROPERTIES_END\r\n");
+    CHECK(detect::DetectAircraft(U8(root)).empty());
 }
 
 TEST("detect: a fresh aircraft reads as not installed") {
@@ -1181,6 +1250,52 @@ TEST("interior: install writes the OBJ, the textures and the .acf spot patch") {
     // ⚠ Slot 3 was `none` in the stock file and must STAY `none` — the patch owns
     // three spots, not four.
     CHECK(Contains(reverted, "_spot_name_3d/3 none"));
+}
+
+TEST("interior: install re-applies the saved cockpit light intensity") {
+    // The multiplier lives in the plugin's prefs and in the OBJ's baked
+    // values. A reinstall stages a fresh 1x OBJ, so without this re-apply
+    // every reinstall silently resets the user's brightness — which reads as
+    // the installer having broken the setting.
+    TempDir tmp;
+    FakePayload pay(tmp / "payload");
+    FakeAircraft fa(tmp.path());
+    Write(fa.folder() / "ToLissA320.acf", StockAcf());
+    Write(fa.root() / "Output" / "preferences" / kProfilesJsonName,
+          "{\n  \"$cockpit\": {\"optimized\": 0, \"intensity\": 2.00}\n}\n");
+
+    actions::Options o = fa.Opts();
+    o.interior = true;
+    actions::Install(o, gLog);
+
+    const std::string obj = Read(fa.objects() / kInteriorObj);
+    CHECK(intensity::SameFactor(intensity::FactorIn(obj), 2.0));
+    // the stub's dome lamp, slot 8 doubled (1.414 -> 2.828)
+    CHECK(Contains(obj, "airplane_panel_sp -0.472 1.09 -3.35 1 0.37 0.16 0 "
+                        "2.828 0 0 0 1"));
+    // ⚠ both sentinels survive the patch: the cockpit-submenu needle and the
+    // installer's own version marker.
+    CHECK(Contains(obj, kInteriorObjNeedle));
+    CHECK(marker::Parse(obj).found);
+}
+
+TEST("interior: no saved intensity stages the payload bytes untouched") {
+    // A user who never moved the slider has no "$cockpit"."intensity" entry —
+    // and their OBJ must carry no trace of the mechanism at all.
+    TempDir tmp;
+    FakePayload pay(tmp / "payload");
+    FakeAircraft fa(tmp.path());
+    Write(fa.folder() / "ToLissA320.acf", StockAcf());
+
+    actions::Options o = fa.Opts();
+    o.interior = true;
+    actions::Install(o, gLog);
+
+    const std::string obj = Read(fa.objects() / kInteriorObj);
+    CHECK(!Contains(obj, intensity::kFactorPrefix));
+    CHECK(!Contains(obj, intensity::kOrigPrefix));
+    CHECK(Contains(obj, "airplane_panel_sp -0.472 1.09 -3.35 1 0.37 0.16 0 "
+                        "1.414 0 0 0 1"));
 }
 
 TEST("interior: the .acf is CRLF on disk and stays CRLF through both directions") {

--- a/tests/test_interior.py
+++ b/tests/test_interior.py
@@ -1125,7 +1125,15 @@ class OptimizedLightCountTests(unittest.TestCase):
         turned it on for a 40-livery folder did not mean "on this one paint"."""
         cpp = (REPO / "src" / "native" / "src" / "plugin.cpp").read_text(
             encoding="utf-8", errors="replace")
-        self.assertIn('kCockpitKey = "$cockpit"', cpp)
+        # The literal moved to constants.h (2026-08-16) because the INSTALLER
+        # now reads this block too (the intensity multiplier) — the plugin must
+        # bind the shared constant, not respell the key, or reader and writer
+        # drift apart.
+        self.assertIn("kCockpitKey = photon::kPrefsCockpitKey", cpp)
+        constants_h = (REPO / "src" / "native" / "src" / "core"
+                       / "constants.h").read_text(encoding="utf-8",
+                                                  errors="replace")
+        self.assertIn('kPrefsCockpitKey[] = "$cockpit"', constants_h)
         # skipped by the livery loop, or EntryFromJson would read it as a
         # phantom aircraft and write it straight back as one
         self.assertIn("if (kv.first == kCockpitKey)", cpp)
@@ -1439,6 +1447,94 @@ class DebugLightBuildTests(unittest.TestCase):
             encoding="utf-8", errors="replace")
         self.assertIn(f"DebugMaxLights  = {B.DEBUG_MAX_LIGHTS}", dev)
         self.assertIn(f'DebugDataRefPrefix   = "{B.DEBUG_LIGHT_DREF}/"', dev)
+
+
+class IntensityMultiplierTests(unittest.TestCase):
+    """The cockpit-light intensity multiplier (2026-08-16): a 1x-4x factor baked
+    into lights_inn.obj's own light lines by core/patch_intensity — the light
+    TYPES stay exactly as Gus authored them (converting them to dataref-driven
+    custom lights was tried and rejected: it changes the look and adds per-frame
+    callbacks), so the value lives in the file and needs an aircraft reload.
+
+    TWO writers apply it — the plugin (Settings-tab slider, and every aircraft
+    load) and the installer (right after staging a fresh interior OBJ) — and
+    these pin the cross-file agreements between them that no compiler checks."""
+
+    @classmethod
+    def setUpClass(cls):
+        native = REPO / "src" / "native" / "src"
+        cls.plugin = (native / "plugin.cpp").read_text(
+            encoding="utf-8", errors="replace")
+        cls.actions = (native / "core" / "actions.cpp").read_text(
+            encoding="utf-8", errors="replace")
+        cls.header = (native / "core" / "patch_intensity.h").read_text(
+            encoding="utf-8", errors="replace")
+
+    def test_the_json_key_is_one_constant_on_both_sides(self):
+        """The plugin WRITES "$cockpit"."intensity" and the installer READS it
+        back (SavedFactor). Each side spelling its own literal is how a reader
+        and a writer drift, so the plugin must go through the shared constants
+        for both the block key and the value key — never a bare literal."""
+        self.assertIn('kIntensityJsonKey[] = "intensity"', self.header)
+        # read (CockpitFromJson) and write (SaveProfilesFile) both go through it
+        self.assertGreaterEqual(
+            self.plugin.count("photon::intensity::kIntensityJsonKey"), 2)
+        self.assertNotIn('"intensity"', self.plugin)
+
+    def test_the_slider_commits_on_release_never_per_drag_tick(self):
+        """The commit rewrites a FILE where every neighboring control flips a
+        flag — per drag tick it would be dozens of rewrites per adjustment."""
+        i = self.plugin.index('SliderFloat("Brightness"')
+        window = self.plugin[i:i + 500]
+        self.assertIn("IsItemDeactivatedAfterEdit()", window)
+        self.assertIn("CommitCockpitIntensity()", window)
+
+    def test_the_apply_gates_on_installed_and_not_stale(self):
+        """⚠ Both, deliberately: gInteriorInstalled because there is nothing of
+        ours to rewrite otherwise, and !gInstallStale because a reverted
+        install's contract is to do NOTHING — file writes included."""
+        self.assertIn("if (!gInteriorInstalled || gInstallStale) return;",
+                      self.plugin)
+
+    def test_the_aircraft_load_path_reapplies_after_the_stale_gate(self):
+        """One saved setting reaches all three A3xx airframes by re-applying on
+        every load — and the call must sit AFTER the stale early-return, or a
+        reverted install would get its OBJ rewritten by the very code path that
+        just promised to do nothing."""
+        i = self.plugin.index("static void UpdateMenuVisibility() {")
+        body = self.plugin[i:self.plugin.index("\n}", i)]
+        self.assertIn('ApplyInteriorIntensity("aircraft load")', body)
+        self.assertGreater(body.index('ApplyInteriorIntensity("aircraft load")'),
+                           body.index("if (gInstallStale) {"))
+
+    def test_the_installer_applies_the_saved_factor_before_the_write(self):
+        """The installer half: SavedFactor(opts.xplaneRoot) patched into the
+        in-memory text BEFORE WriteOrThrow, so the aircraft sees exactly one
+        atomic write and a reinstall cannot silently reset the brightness."""
+        i = self.actions.index("std::vector<std::string> InstallInterior(")
+        body = self.actions[i:i + 3000]
+        saved = body.index("intensity::SavedFactor(opts.xplaneRoot)")
+        patched = body.index("intensity::PatchText(")
+        write = body.index("WriteOrThrow(target, text)")
+        self.assertLess(saved, patched)
+        self.assertLess(patched, write)
+
+    def test_the_settings_row_is_hidden_without_the_mod(self):
+        """Same rule as the simplified-floods row above it: HIDDEN, not grayed,
+        where the cockpit mod is not installed — it drives an OBJ that is not
+        on this aircraft, and a lone row has nowhere to explain itself."""
+        i = self.plugin.index('SeparatorText("Cockpit lighting")')
+        self.assertIn("if (gInteriorInstalled)", self.plugin[i - 800:i])
+
+    def test_the_patcher_only_touches_a_photon_interior_obj(self):
+        """CanPatch requires the interior needle and refuses a --debug build —
+        the stock ToLiss lights_inn.obj must never be rewritten, and a debug
+        OBJ's baked numbers are dead weight the tuning session must not meet."""
+        cpp = (REPO / "src" / "native" / "src" / "core"
+               / "patch_intensity.cpp").read_text(encoding="utf-8",
+                                                  errors="replace")
+        self.assertIn("kInteriorObjNeedle", cpp)
+        self.assertIn("kDebugNeedle", cpp)
 
 
 if __name__ == "__main__":

--- a/tests/test_reinstall_state.py
+++ b/tests/test_reinstall_state.py
@@ -194,11 +194,22 @@ class DetectTests(unittest.TestCase):
         """Airframe::objName is a FINGERPRINT (core/constants.h), so the exterior
         OBJ that is present both names the aeroplane and is the file whose
         contents answer whether we are still installed on it. One read, both
-        answers — and it is why the detector needs no ICAO."""
+        answers.
+
+        ⚠ Since 2026-08-16 the ICAO is read too — but ONLY to corroborate a row
+        whose fingerprint is generic (Airframe::acfIcao, the a339's
+        ExternalLights_XP12.obj, which an A340 also carries). It must stay a
+        guarded veto, never the identifier: only a POSITIVE mismatch may reject,
+        because DetectInstall runs once per load with no 1 Hz retry, and an
+        empty read rejecting would keep a genuine A339 dark all session."""
         body = _code(_fn("DetectInstall"))
         self.assertIn("photon::Airframes()", body)
         self.assertIn("af.objName", body)
-        self.assertNotIn("AircraftIcao()", body)
+        # the corroboration: gated on the row asking for it, and fail-open on
+        # an empty read — the same "evidence may disable, its absence may not"
+        # rule as ScanObj's kObjUnreadable.
+        self.assertIn("af.acfIcao[0] != '\\0'", body)
+        self.assertIn("!icao.empty()", body)
 
     def test_presence_and_content_are_two_separate_questions(self):
         """⚠ Folding them into one scan would make "present but unreadable"


### PR DESCRIPTION
## What changed

**Cockpit light intensity multiplier (1x-4x).** A user reported the Gus-mod cockpit lighting reads too dim (likely another add-on darkening the environment). New Settings tab > Cockpit lighting > **Brightness** slider multiplies every interior light by rewriting the baked `size` values in `lights_inn.obj` in place -- the light types stay exactly as Gus authored them, with no new datarefs or per-frame callbacks. Saved globally in the prefs file; applied on slider release, re-applied on every aircraft load (which carries one setting to all three A3xx airframes), and re-applied by the **installer** after staging a fresh interior OBJ so a reinstall cannot silently reset it. The patch keeps each authored line in an adjacent comment, so re-patching never compounds and 1x restores the file byte-for-byte. Requires an X-Plane restart to see, and both the tooltip and an inline hint say so.

**A340 no longer detected as installable.** The a339's OBJ fingerprint, `ExternalLights_XP12.obj`, is ToLiss's generic filename for every newer-generation airframe -- an A340 ships it too, so the installer listed and would happily install into it. The fingerprint now requires corroboration from the aircraft's own `acf/_ICAO` stamp (`A339`); the plugin does the same check via the sim's ICAO dataref, so an A340 in-sim is unrecognized rather than showing "Reinstall required". Fails open for the real A339 (unreadable `.acf` files fall through to the folder-name glob; in the plugin only a positive ICAO mismatch rejects).

## Verification

- 193 C++ tests (13 new: `intensity:` patcher group, installer re-apply, A340 detect cases) and 760 Python tests (new `IntensityMultiplierTests` cross-file pins) all pass
- Release plugin, dev plugin, and installer binary all build clean
- Ran the built installer's `detect --json` against a real X-Plane install: A319/A320/A321/A339 all still detect correctly

Not yet verified in-sim: how 1x-4x reads visually on the lamps (the lever is one multiplier in `core/patch_intensity.cpp` if the range needs retuning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)